### PR TITLE
Needs bytestring >= 0.10.2 due to Data.ByteString.Builder

### DIFF
--- a/network-carbon.cabal
+++ b/network-carbon.cabal
@@ -16,7 +16,7 @@ library
 
   build-depends:
     base >=4.6 && <4.9,
-    bytestring >=0.9 && <0.11,
+    bytestring >=0.10.2 && <0.11,
     network >= 2.4 && < 2.7,
     text >= 0.10 && < 1.3,
     time >= 1.4 && < 1.6,


### PR DESCRIPTION
This fixes `cabal install network-carbon` on GHC 7.4.

I revised the last three releases: https://hackage.haskell.org/package/network-carbon/revisions/ , a new release isn't required.
