### PR TITLE
Add compatibility to base 4.13, 4.14, network 3

### DIFF
--- a/network-carbon.cabal
+++ b/network-carbon.cabal
@@ -15,9 +15,9 @@ library
     Network.Carbon.Plaintext
 
   build-depends:
-    base >=4.6 && <4.13,
+    base >=4.6 && <4.15,
     bytestring >=0.10.2 && <0.11,
-    network >= 2.4 && < 2.9,
+    network >= 2.4 && <3.2,
     text >= 0.10 && < 1.3,
     time >= 1.4 && < 1.10,
     vector >= 0.10 && < 0.13


### PR DESCRIPTION
Network 3 drops the `isWritable` function (it was an alias to `isReadable` long before that). Let's just try to write and catch the `ResourceVanished` error.
(Todo: will this end up in an infinite loop?)